### PR TITLE
EZEE-1444: Store StudioUI 3rd-party dependencies in a separate bundle

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "Resources/public/vendors/"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Resources/public/vendors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+    - "node"
+
+before_script:
+    - sudo ./bin/travis/setupphp.sh
+    - curl -sS https://getcomposer.org/installer | php
+    - npm install -g bower
+
+script:
+    - ./composer.phar validate
+    - ./composer.phar install
+    - bower install
+    - npm install
+    - npm run build

--- a/EzSystemsPlatformEEAssetsBundle.php
+++ b/EzSystemsPlatformEEAssetsBundle.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EzSystems\PlatformEEAssetsBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class EzSystemsPlatformEEAssetsBundle extends Bundle
+{
+    protected $name = 'eZPlatformEEAssetsBundle';
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # ezplatform-ee-assets
+
+## Installing dependencies
+
+1. `bower install`
+2. `npm install`
+3. `npm run build`

--- a/bin/travis/setupphp.sh
+++ b/bin/travis/setupphp.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+add-apt-repository -y ppa:ondrej/php5
+apt-get update -q
+apt-get install -y php5-cli php5-common php5-gd php5-xsl php5-intl

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "ez-platform-ee-assets-bundle",
+  "version": "1.0.0",
+  "homepage": "https://github.com/ezsystems/ezplatform-ee-assets",
+  "authors": [
+    "eZ Systems"
+  ],
+  "license": "GPL-2.0",
+  "private": true,
+  "ignore": [
+    "*",
+    "**/.*",
+    "Resources/public/vendors/"
+  ],
+  "dependencies": {
+    "dragsterjs": "^1.4.1",
+    "fixed-data-table": "^0.6.3",
+    "postscribe-min": "https://cdnjs.cloudflare.com/ajax/libs/postscribe/2.0.8/postscribe.min.js",
+    "react": "^15.4.2"
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "ezsystems/ezplatform-ee-assets",
+    "description": "External assets dependencies for StudioUIBundle",
+    "license": "GPL-2.0",
+    "authors": [
+        {
+            "name": "Piotr Nalepa",
+            "email": "piotr.nalepa@ez.no"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "EzSystems\\PlatformEEAssetsBundle\\": ""
+        }
+    },
+    "scripts": {
+        "build": [
+            "bower install",
+            "npm install",
+            "npm run build"
+        ],
+        "post-install-cmd": [
+            "@build"
+        ],
+        "post-update-cmd": [
+            "@build"
+        ],
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ezplatform-ee-asstets",
+  "version": "1.0.0",
+  "description": "External assets dependencies for StudioUIBundle",
+  "main": "index.js",
+  "scripts": {
+    "concat": "concat",
+    "build-fixed-datatable": "concat Resources/public/vendors/react/react.min.js Resources/public/vendors/react/react-dom.min.js Resources/public/vendors/fixed-data-table/dist/fixed-data-table.min.js -o Resources/public/vendors/fixed-data-table/fixed-data-table-with-react.js",
+    "build": "npm run build-fixed-datatable"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ezsystems/ezplatform-ee-assets.git"
+  },
+  "author": "eZ Systems",
+  "license": "GPL-2.0",
+  "bugs": {
+    "url": "https://github.com/ezsystems/ezplatform-ee-assets/issues"
+  },
+  "homepage": "https://github.com/ezsystems/ezplatform-ee-assets#readme",
+  "dependencies": {
+    "concat": "^3.0.0",
+  },
+  "devDependencies": {
+    "concat": "^3.0.0"
+  }
+}


### PR DESCRIPTION
https://jira.ez.no/browse/EZEE-1444

In order to have the dependencies installed correctly, you have to run the following commands:

1. `npm install -g bower`
2. `bower install`
3. `npm install`
4. `npm run build`

These commands will prepare files to be installed as StudioUIBundle dependencies.